### PR TITLE
Bug 1076810 - RelEng CI tests should be available over the internet, add irc notifications for balrog-ui repository,r=mgerva

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,18 @@ language: node_js
 node_js:
 - 0.10
 script: "lineman spec-ci"
+
+# currently cannot customise per user fork, see:
+# https://github.com/travis-ci/travis-ci/issues/1094
+# please comment out this section in your personal fork!
+notifications:
+  irc:
+    channels:
+      - "irc.mozilla.org#releng"
+    on_success: always
+    on_failure: always
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
+      - "Change view : %{compare_url}"
+      - "Build details : %{build_url}"
+      - "Commit message : %{commit_message}"


### PR DESCRIPTION
Hey Massimo,
A review request for you! Basically, I spotted this repo was failing in travis from looking at http://egeloen.fr/travis-wall/#/petemoore and then I noticed there are no irc notifications, so this might be why nobody noticed. Therefore I added irc notifications to it. We got this from the last build:

travis-ci [travis-ci@moz-0eh38k.compute-1.amazonaws.com] entered the room.
travis-ci
12:27:48 petemoore/balrog-ui#1 (bug1076810 - 88bbb95 : Pete Moore): The build failed.
12:27:48 Change view : https://github.com/petemoore/balrog-ui/commit/88bbb95798fa
12:27:48 Build details : http://travis-ci.org/petemoore/balrog-ui/builds/46059207
12:27:48 Commit message : Bug 1076810 - RelEng CI tests should be available over the internet, add irc notifications for balrog-ui repository,r=mgerva
12:27:48 travis-ci left the room.

I already put the r=mgerva in the commit message, so that if you accept the merge request, the comment will reflect it. This commit only lives in my own personal fork at the moment.

Thanks,
Pete