### PR TITLE
Remove 'version' from releases UI.

### DIFF
--- a/app/js/controllers/releases_controller.js
+++ b/app/js/controllers/releases_controller.js
@@ -58,14 +58,6 @@ function($scope, $routeParams, $location, $timeout, Releases, Search, $modal) {
         text: "Product (reverse)",
         value: "-product"
       },
-      {
-        text: "Version",
-        value: "version"
-      },
-      {
-        text: "Version (reverse)",
-        value: "-version"
-      },
     ];
   }
   $scope.ordering_str = $scope.ordering_options[0];
@@ -108,10 +100,6 @@ function($scope, $routeParams, $location, $timeout, Releases, Search, $modal) {
         var on = each[1];
         // console.log(regex, on);
         if ((on === '*' || on === 'product') && release.product && release.product.match(regex)) {
-          matches++;
-          return;
-        }
-        if ((on === '*' || on === 'version') && release.version && release.version.match(regex)) {
           matches++;
           return;
         }

--- a/app/templates/release_data_modal.html
+++ b/app/templates/release_data_modal.html
@@ -1,6 +1,5 @@
 <div class="modal-header">
-    <h3 class="modal-title">Release Data for {{ release.product }} {{ release.version }}</h3>
-    <h4 class="modal-title">{{ release.name }}</h3>
+    <h3 class="modal-title">Release Data for {{ release.name }}</h3>
 </div>
 <div class="modal-body">
   <pre ng-if="!diff">{{ release.data | json }}</pre>

--- a/app/templates/release_delete_modal.html
+++ b/app/templates/release_delete_modal.html
@@ -6,8 +6,6 @@
   <dl class="dl-horizontal">
     <dt>Product:</dt>
     <dd>{{ release.product }}</dd>
-    <dt>Version:</dt>
-    <dd>{{ release.version }}</dd>
     <dt>Name:</dt>
     <dd>{{ release.name }}</dd>
   </dl>

--- a/app/templates/release_modal.html
+++ b/app/templates/release_modal.html
@@ -9,16 +9,10 @@
       <input type="text" class="form-control" id="id_name" ng-model="release.name" ng-disabled="is_edit">
       <p class="help-block" ng-show="errors.name">{{ errors.name.join(', ') }}</p>
     </div>
-    <div class="form-group" ng-class="{'has-error': errors.version}">
     <div class="form-group" ng-class="{'has-error': errors.product}">
       <label for="id_product">Product</label>
       <input type="text" class="form-control" id="id_product" ng-model="release.product">
       <p class="help-block" ng-show="errors.product">{{ errors.product.join(', ') }}</p>
-    </div>
-    <div class="form-group" ng-class="{'has-error': errors.version}">
-      <label for="id_version">Version</label>
-      <input type="text" class="form-control" id="id_version" ng-model="release.version">
-      <p class="help-block" ng-show="errors.version">{{ errors.version.join(', ') }}</p>
     </div>
     <div class="form-group" ng-class="{'has-error': errors.data}">
       <label for="id_data">Data</label>

--- a/app/templates/release_revert_modal.html
+++ b/app/templates/release_revert_modal.html
@@ -6,8 +6,6 @@
   <dl class="dl-horizontal">
     <dt>Product:</dt>
     <dd>{{ release.product }}</dd>
-    <dt>Version:</dt>
-    <dd>{{ release.version }}</dd>
     <dt>Name:</dt>
     <dd>{{ release.name }}</dd>
   </dl>

--- a/app/templates/releases.html
+++ b/app/templates/releases.html
@@ -83,8 +83,7 @@
   </div>
   <div class="panel-body">
     <div class="left" style="float: left">
-      <b title="Product" ng-bind-html="highlightSearch(release.product, 'product')"></b>
-      <b title="Version" ng-bind-html="highlightSearch(release.version, 'version')"></b>
+      <span>Product: <b title="Product" ng-bind-html="highlightSearch(release.product, 'product')"></b></span>
 
       <h5 title="Data version">
         Data version: <b>{{ release.data_version }}</b>


### PR DESCRIPTION
As this is an unused column, most of the changes here are test code. I did some basic futzing in the UI to verify this patch as well (adding, removing, changing a release), and a quick sanity check that a basic request to the public interface returns a response.